### PR TITLE
Automatization: libraries validation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     `maven-publish`
     id("com.redmadrobot.publish-config") version "0.17"
     id("com.redmadrobot.publish") version "0.17" apply false
+    id("com.redmadrobot.version-catalog-extensions") version "0.1" apply false
 }
 
 repositories {
@@ -36,6 +37,7 @@ subprojects {
     apply {
         plugin("org.gradle.version-catalog")
         plugin("com.redmadrobot.publish")
+        plugin("com.redmadrobot.version-catalog-extensions")
     }
 
     group = "com.redmadrobot.versions"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,10 +8,6 @@ plugins {
     id("com.redmadrobot.version-catalog-extensions") version "0.1" apply false
 }
 
-repositories {
-    mavenCentral()
-}
-
 redmadrobot {
     publishing {
         signArtifacts.set(true)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,6 +5,17 @@ pluginManagement {
     }
 }
 
+@Suppress("UnstableApiUsage")
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenCentral()
+        google()
+        gradlePluginPortal()
+        maven("https://jitpack.io")
+    }
+}
+
 rootProject.name = "versions"
 
 includeBuild("version-catalog-extensions")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,3 @@
-enableFeaturePreview("VERSION_CATALOGS")
-
 pluginManagement {
     repositories {
         gradlePluginPortal()
@@ -9,6 +7,7 @@ pluginManagement {
 
 rootProject.name = "versions"
 
+includeBuild("version-catalog-extensions")
 include(
     "versions-androidx",
     "versions-redmadrobot",

--- a/version-catalog-extensions/build.gradle.kts
+++ b/version-catalog-extensions/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+    `kotlin-dsl`
+}
+
+group = "com.redmadrobot.gradle"
+version = "0.1"
+
+gradlePlugin {
+    plugins {
+        create("versionCatalogExtensions") {
+            id = "com.redmadrobot.version-catalog-extensions"
+            implementationClass = "com.redmadrobot.gradle.catalog.VersionCatalogExtensionsPlugin"
+        }
+    }
+}
+
+repositories {
+    mavenCentral()
+}

--- a/version-catalog-extensions/settings.gradle.kts
+++ b/version-catalog-extensions/settings.gradle.kts
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("stack") {
+            from(files("../versions-stack/libs.versions.toml"))
+        }
+    }
+}

--- a/version-catalog-extensions/src/main/kotlin/ValidateVersionCatalogTask.kt
+++ b/version-catalog-extensions/src/main/kotlin/ValidateVersionCatalogTask.kt
@@ -1,0 +1,59 @@
+package com.redmadrobot.gradle.catalog
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.attributes.Usage
+import org.gradle.api.internal.catalog.DefaultVersionCatalog
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.named
+
+abstract class ValidateVersionCatalogTask : DefaultTask() {
+
+    @get:Input
+    abstract val dependenciesModel: Property<DefaultVersionCatalog>
+
+    @TaskAction
+    fun validate() {
+        val catalog = dependenciesModel.get()
+
+        // Check libraries in catalog are resolvable
+        val configuration = createConfiguration()
+        configuration.addLibraries(catalog)
+        println("Resolved dependencies:")
+        configuration.resolvedConfiguration
+            .firstLevelModuleDependencies
+            .forEach { println("- ${it.name}") }
+    }
+
+    private fun createConfiguration(): Configuration {
+        return project.configurations.create(CONFIGURATION_NAME) {
+            isTransitive = false
+            isCanBeResolved = true
+
+            attributes {
+                attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage.JAVA_API))
+            }
+
+            // Ignore capabilities conflicts
+            resolutionStrategy.capabilitiesResolution.all {
+                select(candidates.first())
+            }
+        }
+    }
+
+    private fun Configuration.addLibraries(catalog: DefaultVersionCatalog) {
+        catalog.libraryAliases
+            .asSequence()
+            .map(catalog::getDependencyData)
+            .forEach { dependency ->
+                val dependencyNotation = "${dependency.group}:${dependency.name}:${dependency.version}"
+                project.dependencies.add(name, dependencyNotation)
+            }
+    }
+
+    private companion object {
+        const val CONFIGURATION_NAME = "libraries"
+    }
+}

--- a/version-catalog-extensions/src/main/kotlin/ValidateVersionCatalogTask.kt
+++ b/version-catalog-extensions/src/main/kotlin/ValidateVersionCatalogTask.kt
@@ -10,11 +10,17 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 import org.gradle.kotlin.dsl.named
+import org.gradle.language.base.plugins.LifecycleBasePlugin
 
 abstract class ValidateVersionCatalogTask : DefaultTask() {
 
     @get:Input
     abstract val dependenciesModel: Property<DefaultVersionCatalog>
+
+    init {
+        group = LifecycleBasePlugin.VERIFICATION_GROUP
+        description = "Validates version catalog"
+    }
 
     @TaskAction
     fun validate() {
@@ -23,10 +29,10 @@ abstract class ValidateVersionCatalogTask : DefaultTask() {
         // Check libraries in catalog are resolvable
         val configuration = createConfiguration()
         configuration.addLibraries(catalog)
-        println("Resolved dependencies:")
+        logger.debug("Resolved dependencies:")
         configuration.resolvedConfiguration
             .firstLevelModuleDependencies
-            .forEach { println("- ${it.name}") }
+            .forEach { logger.debug("- ${it.name}") }
 
         catalog.checkVersionsUsed()
     }

--- a/version-catalog-extensions/src/main/kotlin/VersionCatalogExtensionsPlugin.kt
+++ b/version-catalog-extensions/src/main/kotlin/VersionCatalogExtensionsPlugin.kt
@@ -1,0 +1,17 @@
+package com.redmadrobot.gradle.catalog
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.plugins.catalog.internal.CatalogExtensionInternal
+import org.gradle.kotlin.dsl.getByName
+import org.gradle.kotlin.dsl.register
+
+class VersionCatalogExtensionsPlugin : Plugin<Project> {
+
+    override fun apply(target: Project) {
+        val extension = target.extensions.getByName<CatalogExtensionInternal>("catalog")
+        target.tasks.register<ValidateVersionCatalogTask>("validateCatalog") {
+            dependenciesModel.set(extension.versionCatalog)
+        }
+    }
+}

--- a/version-catalog-extensions/src/main/kotlin/VersionCatalogExtensionsPlugin.kt
+++ b/version-catalog-extensions/src/main/kotlin/VersionCatalogExtensionsPlugin.kt
@@ -2,16 +2,24 @@ package com.redmadrobot.gradle.catalog
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.plugins.catalog.VersionCatalogPlugin.GENERATE_CATALOG_FILE_TASKNAME
 import org.gradle.api.plugins.catalog.internal.CatalogExtensionInternal
 import org.gradle.kotlin.dsl.getByName
 import org.gradle.kotlin.dsl.register
+import org.gradle.language.base.plugins.LifecycleBasePlugin.CHECK_TASK_NAME
 
 class VersionCatalogExtensionsPlugin : Plugin<Project> {
 
-    override fun apply(target: Project) {
-        val extension = target.extensions.getByName<CatalogExtensionInternal>("catalog")
-        target.tasks.register<ValidateVersionCatalogTask>("validateCatalog") {
+    override fun apply(target: Project) = with(target) {
+        val extension = extensions.getByName<CatalogExtensionInternal>("catalog")
+        val validateCatalog = tasks.register<ValidateVersionCatalogTask>(VALIDATE_CATALOG_TASK_NAME) {
             dependenciesModel.set(extension.versionCatalog)
+            dependsOn(tasks.named(GENERATE_CATALOG_FILE_TASKNAME))
         }
+        tasks.named(CHECK_TASK_NAME).configure { dependsOn(validateCatalog) }
+    }
+
+    companion object {
+        const val VALIDATE_CATALOG_TASK_NAME = "validateCatalog"
     }
 }

--- a/version-catalog-extensions/src/main/kotlin/VersionCatalogExtensionsPlugin.kt
+++ b/version-catalog-extensions/src/main/kotlin/VersionCatalogExtensionsPlugin.kt
@@ -2,8 +2,10 @@ package com.redmadrobot.gradle.catalog
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.plugins.BasePlugin
 import org.gradle.api.plugins.catalog.VersionCatalogPlugin.GENERATE_CATALOG_FILE_TASKNAME
 import org.gradle.api.plugins.catalog.internal.CatalogExtensionInternal
+import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.getByName
 import org.gradle.kotlin.dsl.register
 import org.gradle.language.base.plugins.LifecycleBasePlugin.CHECK_TASK_NAME
@@ -11,6 +13,17 @@ import org.gradle.language.base.plugins.LifecycleBasePlugin.CHECK_TASK_NAME
 class VersionCatalogExtensionsPlugin : Plugin<Project> {
 
     override fun apply(target: Project) = with(target) {
+        if (!plugins.hasPlugin("org.gradle.version-catalog")) {
+            logger.warn(
+                """
+                Can not apply plugin com.redmadrobot.version-catalog-extensions:
+                    Plugin org.gradle.version-catalog not found but it is required
+                """.trimIndent()
+            )
+            return@with
+        }
+        apply<BasePlugin>()
+
         val extension = extensions.getByName<CatalogExtensionInternal>("catalog")
         val validateCatalog = tasks.register<ValidateVersionCatalogTask>(VALIDATE_CATALOG_TASK_NAME) {
             dependenciesModel.set(extension.versionCatalog)

--- a/versions-redmadrobot/build.gradle.kts
+++ b/versions-redmadrobot/build.gradle.kts
@@ -1,7 +1,1 @@
-import com.redmadrobot.build.dsl.jitpack
-
 description = "Version catalog with red_mad_robot libraries"
-
-repositories {
-    jitpack()
-}

--- a/versions-redmadrobot/build.gradle.kts
+++ b/versions-redmadrobot/build.gradle.kts
@@ -1,1 +1,7 @@
-description = "Version catalog with common red_mad_robot libraries"
+import com.redmadrobot.build.dsl.jitpack
+
+description = "Version catalog with red_mad_robot libraries"
+
+repositories {
+    jitpack()
+}

--- a/versions-stack/build.gradle.kts
+++ b/versions-stack/build.gradle.kts
@@ -1,7 +1,1 @@
-import com.redmadrobot.build.dsl.jitpack
-
 description = "Version catalog with dependencies used in red_mad_robot"
-
-repositories {
-    jitpack()
-}

--- a/versions-stack/build.gradle.kts
+++ b/versions-stack/build.gradle.kts
@@ -1,1 +1,7 @@
+import com.redmadrobot.build.dsl.jitpack
+
 description = "Version catalog with dependencies used in red_mad_robot"
+
+repositories {
+    jitpack()
+}


### PR DESCRIPTION
We need to add automated checks that:

- [x] libraries can be resolved
- [x] all of version aliases are used in `libraries` and `plugins`
