### PR TITLE
Add CLAUDE.md and Claude Code project config for coding agent support

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(bash .claude/skills/update-version-catalog/scripts/:*)"
+    ]
+  }
+}

--- a/.claude/skills/update-version-catalog/SKILL.md
+++ b/.claude/skills/update-version-catalog/SKILL.md
@@ -1,0 +1,785 @@
+---
+name: update-version-catalog
+description: >-
+  Use EVERY time the user asks to update / bump the version catalogs, "сделать
+  обновление", "обновить каталог(и)", "обнови версии", "оформи изменения",
+  "update the catalog", or to record dependency version changes in the
+  changelog. Renovate commits the version bumps into versions-*/libs.versions.toml;
+  this skill collects those changes, records them in CHANGELOG.md following the
+  format rules below, and validates with `./gradlew validateCatalog`. ALSO use
+  it when the user asks to add a new dependency ("добавь зависимость",
+  "add dependency") giving Maven coordinates like "group:artifact" — the skill
+  finds the latest stable version, adds it to the right catalog, and records it
+  in the changelog.
+---
+
+# Update Version Catalog
+
+Renovate is the source of version updates: it keeps each dependency bump on its
+own remote branch `origin/renovate/<dep>` (e.g. `origin/renovate/dagger`,
+`origin/renovate/compose-bom`), with a commit topic like `stack: dagger 2.60`.
+This skill does NOT invent versions — it collects Renovate's bumps onto a fresh
+working branch, documents them in `CHANGELOG.md`, and validates the catalogs.
+
+This document is self-contained: all `CHANGELOG.md` formatting rules are inlined
+below.
+
+---
+
+## HARD RULE — respond in Russian
+
+All output shown to the user — progress updates, questions, summaries, and the
+final report — MUST be written strictly in Russian, regardless of the language
+of the user's request. This applies only to the assistant's messages; code,
+commit messages, `CHANGELOG.md` entries, and file contents follow their own
+existing conventions and are unaffected.
+
+---
+
+## HARD RULE — work only on the created branch
+
+All work happens on the single `dev-update-YYYY-MM-DD` branch created in step 1.
+
+- **NEVER** commit, amend, reset, rebase, cherry-pick, push, or otherwise mutate
+  any other branch — **especially `main`**. `main` may only be read (fetched /
+  pulled fast-forward in step 1) and used as the cherry-pick/reset base.
+- Confirm you are on the working branch before every commit/amend/reset
+  (`git branch --show-current` → must be `dev-update-*`). If it is not, STOP and
+  fix the branch before running the command.
+- Do NOT touch `release/*` or `origin/renovate/*` branches (renovate branches are
+  read-only sources for cherry-pick).
+- Do NOT `git push` anything unless I explicitly ask.
+
+If any step would require changing a branch other than the working one, STOP and
+ask me instead of proceeding.
+
+---
+
+## Command types — recognise what was asked before starting
+
+Every command is one of three kinds:
+
+| The user asks | Flow to follow | Commits produced |
+| ------------- | -------------- | ---------------- |
+| **Update** existing dependencies («обнови зависимости/каталоги», «сделай обновление», "update") | Workflow steps 1–10 | **1** update commit: all cherry-picked bumps + their `CHANGELOG.md` entries |
+| **Add** new dependencies («добавь зависимость …», "add <group:artifact>") | "Adding a new dependency" section (its step 1 = workflow step 1) | **1** addition commit: catalog edits + their `CHANGELOG.md` entries |
+| **Both at once** («обнови зависимости и добавь …») | TWO operations, both mandatory: workflow steps 1–9 **in full first**, then (step 10) the ENTIRE addition flow on top of the finished update commit | **2** commits: first the update commit, then the addition commit — never mixed |
+
+All additions requested by one command share a single addition commit, no
+matter how many dependencies are added. A correction to an earlier result
+(«исправь ссылку», «поправь changelog») is none of these — it is a
+continuation of the previous command (see workflow step 1) and creates no new
+commit.
+
+**Before doing ANYTHING else, classify the command against this table and tell
+the user (in Russian) which kind it is.** For a **Both at once** command,
+explicitly announce the plan as two numbered operations — e.g. «Команда
+двойная: 1) обновление каталогов, 2) добавление <deps>. Начинаю с
+обновления.» — and track both as separate items in your task list so neither
+can be dropped.
+
+### HARD RULE — "Both at once" is TWO sequential operations, never one
+
+A command that both updates and adds (any phrasing that combines them:
+«обнови зависимости и добавь X», «сделай обновление и добавь X», "update the
+catalogs and add X", or an addition mentioned anywhere in an update request)
+is NOT one task. It is TWO complete, sequential operations:
+
+1. **Operation 1 — Update:** workflow steps 1–9, all the way through
+   validation, producing the update commit.
+2. **Operation 2 — Addition:** the ENTIRE "Adding a new dependency" flow
+   (its steps 2–7; step 1 is skipped — the branch already exists), producing a
+   SECOND, separate commit on top of the update commit.
+
+Finishing operation 1 does NOT complete the command. Do NOT report results,
+do NOT stop, do NOT wait for further input after the update — continue
+straight into operation 2. The command is complete ONLY when
+`git log origin/main..HEAD` shows BOTH commits (update + addition) and both
+passed validation. If you are about to write the final summary and the user's
+request mentioned adding a dependency but there is no addition commit — you
+are not done; go back and perform operation 2.
+
+---
+
+## Commit rules — one command, which commits
+
+- **Update and addition are separate commits.** When a single command asks both
+  to update dependencies AND to add new ones ("обнови зависимости и добавь
+  <deps>") — the "Both at once" row of the command-types table — produce
+  **two commits**: first the update commit (all cherry-picked
+  bumps + their `CHANGELOG.md` entries), then the addition commit (catalog
+  edits + their `CHANGELOG.md` entries). Each commit follows the same rules —
+  changelog folded into its own commit, lint, link checks, validation. Never mix
+  bumps and additions in one commit.
+- **Never amend or rewrite commits that existed before the current command.**
+  Amending is allowed only for a commit created while executing the current
+  command (e.g. folding `CHANGELOG.md` or lint fixes into it). If the
+  `dev-update-*` branch already exists and carries commits from an earlier
+  command or session, record the current command's result as **new commit(s) on
+  top** — do not amend, reset, or squash into the old ones. This is enforced by
+  the **command base** recorded by `start-update.sh` (workflow step 1):
+  `squash-commit.sh` and `commit-release.sh` refuse to rewrite commits at or
+  below it — which is why `start-update.sh` must run at the start of every
+  command, and only then. A correction to this session's result is a
+  continuation of the previous command, not a new command — see workflow
+  step 1.
+
+---
+
+## Catalog distribution rule
+
+Which catalog a dependency belongs to is decided **by its Maven group alone** —
+never by product name, ecosystem, or vendor. Apply the first matching rule:
+
+| Maven group | Catalog |
+| ----------- | ------- |
+| `androidx.*` | `versions-androidx` |
+| `com.redmadrobot.*` | `versions-redmadrobot` |
+| everything else | `versions-stack` |
+
+Explicit consequences (do NOT ask about these — the rule already decides):
+
+- `org.jetbrains.compose.*` (Compose Multiplatform), `org.jetbrains.androidx.*`
+  (multiplatform ports of AndroidX libraries), `org.jetbrains.kotlin*`,
+  `org.jetbrains.kotlinx.*`, `org.jetbrains.dokka.*` → **`versions-stack`**.
+  "Compose" or "androidx" in the *name* does not move a JetBrains group into
+  `versions-androidx`.
+- `com.google.android.material` (Material Components), `com.google.*`,
+  `com.squareup.*`, Firebase, Dagger, testing frameworks, Gradle plugins →
+  **`versions-stack`**.
+- Android testing libraries in the `androidx.test.*` group →
+  **`versions-androidx`** (group starts with `androidx.`).
+- Gradle plugins follow the same rule by their **plugin id / marker group**:
+  `org.jetbrains.*`, `dev.*`, `com.*` etc. → `versions-stack` unless the id
+  starts with `androidx.` or `com.redmadrobot.`.
+
+If a dependency genuinely does not fit (e.g. a new red_mad_robot group that is
+not `com.redmadrobot.*`), STOP and ask — do not guess a catalog.
+
+---
+
+## Workflow
+
+All git operations use the ready-made scripts in
+`.claude/skills/update-version-catalog/scripts/` — do NOT hand-write git
+commands, run these instead (via the Bash tool / Git Bash). Every mutating
+script guards that HEAD is a `dev-update-*` branch and uses `origin/main` only as
+a read-only base, enforcing the HARD RULE above; the command base recorded by
+`start-update.sh` additionally protects earlier commands' commits from
+amend/squash (see "Commit rules").
+
+| Script | Purpose |
+| ------ | ------- |
+| `list-renovate-updates.sh` | Fetch + list all renovate branches ahead of main, with bumps & diffs (read-only) |
+| `start-update.sh [YYYY-MM-DD]` | Start a command: fetch ALL remote branches (incl. every `origin/renovate/*`), create/switch to (or stay on) the `dev-update-*` working branch and record the command base — run once at the start of every command |
+| `cherry-pick-renovate.sh [names…]` | Cherry-pick all (or named) renovate branches onto the working branch |
+| `squash-commit.sh ["msg"]` | Squash all picked commits into one |
+| `show-version-diffs.sh` | Show catalog version diffs in the release commit (read-only) |
+| `find-latest-version.sh <group:artifact>…` | Latest stable version of an artifact from Google Maven / Maven Central / Plugin Portal (read-only) |
+| `resolve-doc-url.sh <group:artifact> <version>` | Resolve a dependency's doc URL (new or updated) from its POM HomePage, then find the matching GitHub release/tag for the version (read-only) |
+| `commit-release.sh ["msg"]` | Create or amend the current command's commit (update or addition) with catalog + `CHANGELOG.md` changes |
+| `lint-changelog.sh [--skip-renovate]` | Cross-check `[Unreleased]` entries against the release diff, format rules, and renovate branches (read-only) |
+| `check-changelog-urls.sh` | Reachability + redirect check of URLs added to `CHANGELOG.md` (read-only) |
+
+### 1. Fetch and create the working branch — run at the start of EVERY command
+
+First check where you are: `git branch --show-current`.
+
+- **On `main` or already on a `dev-update-*` branch** → run:
+
+  ```bash
+  bash .claude/skills/update-version-catalog/scripts/start-update.sh
+  ```
+
+  The script ALWAYS starts by fetching **all** remote branches with an explicit
+  refspec (`+refs/heads/*:refs/remotes/origin/*` + `--prune`), so the fresh
+  `origin/main` and every current `origin/renovate/*` branch are available
+  BEFORE the working branch is created. On `main` it then creates
+  `dev-update-YYYY-MM-DD` (today's date) off the freshly fetched `origin/main`;
+  local `main` is never modified. Pass an explicit `YYYY-MM-DD` to override the
+  date. Already on a `dev-update-*` branch it stays there — the current
+  command's results become new commit(s) on this branch (see "Commit rules").
+
+  In both cases the script records the **command base** (current HEAD):
+  `squash-commit.sh` and `commit-release.sh` refuse to rewrite anything at or
+  below it, protecting earlier commands' commits. Run it exactly **once per
+  command, at the start** — never mid-command (that would move the base
+  past the commit you are still building and block `commit-release.sh`).
+
+  **What counts as a command.** A command is a user request that starts a NEW
+  update or addition task («обнови каталоги», «добавь зависимость …»). A
+  follow-up request that corrects the result already produced in this session
+  («исправь ссылку», «поправь changelog», fixing a lint/link problem you
+  reported) is a **continuation of the previous command, NOT a new command**:
+  do NOT re-run `start-update.sh` for it — that would move the command base
+  onto the very commit you need to fix and `commit-release.sh` would refuse to
+  amend it. Just edit the files and re-amend with `commit-release.sh` as
+  usual.
+- **On any other branch** (`release/*`, feature branch, …) → STOP and ask me
+  which branch to work on; do not guess.
+
+### 2. Cherry-pick the Renovate bumps
+
+First review what is available, then cherry-pick:
+
+```bash
+bash .claude/skills/update-version-catalog/scripts/list-renovate-updates.sh
+bash .claude/skills/update-version-catalog/scripts/cherry-pick-renovate.sh          # all
+# or a subset: ... cherry-pick-renovate.sh dagger kotest hilt
+```
+
+Cherry-pick **every** renovate branch that has a new commit — not only the ones
+touching `versions-*/libs.versions.toml`. Infrastructure updates such as the
+Gradle wrapper (`gradle/wrapper/*`) and GitHub Actions (`.github/workflows/*`)
+belong in the release commit too; they just do NOT get a `CHANGELOG.md` entry
+(see "What NOT to record"). Skip a branch only if I explicitly say so — mention
+what you skipped.
+
+On a conflict the script stops mid-cherry-pick. Resolve it in
+`versions-*/libs.versions.toml` by keeping the newer version, `git add` the
+file, then `GIT_EDITOR=true git cherry-pick --continue` (the `GIT_EDITOR=true`
+is required — plain `--continue` opens an interactive editor for the commit
+message and would hang the session). Then simply re-run the script — commits
+already applied to HEAD are skipped automatically.
+
+### 3. Squash the cherry-picked commits into one
+
+All bumps collected by the **current command** must live in a **single commit** —
+the `CHANGELOG.md` changes are added to that same commit later (step 8).
+
+```bash
+bash .claude/skills/update-version-catalog/scripts/squash-commit.sh
+```
+
+The script builds the commit message itself (the subjects of the squashed
+commits, oldest first, one per line — the same style as existing release
+commits on `main`). Do NOT pass a message argument unless I explicitly asked
+for a specific one.
+
+After this, on a fresh branch `git log origin/main..HEAD` shows exactly one
+commit. If the branch already carried commits from an earlier command, squash
+ONLY the commits cherry-picked by the current command (see "Commit rules") —
+the log then shows the old commits plus one new update commit.
+
+### 4. Extract old → new versions per catalog
+
+```bash
+bash .claude/skills/update-version-catalog/scripts/show-version-diffs.sh
+```
+
+From the output, collect per changed `libs.versions.toml`: library/plugin name,
+old version (`-` lines), new version (`+` lines). Classify each as added /
+updated / removed / renamed (see symbols below).
+
+**Version-format change — require confirmation.** Compare the *shape* of the new
+version against the previous one (number of dot-separated parts, presence of a
+pre-release/suffix, dash-separated compound, calendar/BOM style). If the new
+version's format **differs** from the old version's format, do NOT proceed
+automatically — stop and ask me to confirm, showing the library name with its
+**old → new** version. Continue only after I confirm.
+
+**Exception — do NOT trigger the guard** when the only difference is that a
+trailing numeric segment was added (or dropped) while the shared leading numeric
+segments are unchanged. Gaining/losing a plain patch component is a normal
+version, not a format change:
+- `2.60` → `2.60.1` (patch segment appended — OK, no confirmation)
+- `1.2.3` → `1.2` (trailing segment dropped — OK)
+
+Examples that trigger the guard (format genuinely changed):
+- `1.1.0` → `1.1.1-beta03` (plain → pre-release suffix)
+- `1.9.5` → `2026.06.00` (semver → calendar/BOM)
+- `0.7.1` → `0.8.0-0.6.x-compat` (plain → dash-separated compound/suffix)
+
+Examples that do NOT trigger it (same format):
+- `1.1.0` → `1.2.0`
+- `2.2.20-2.0.3` → `2.2.20-2.0.4`
+- `1.1.1-beta02` → `1.1.1-beta03`
+
+For added dependencies (no old version) this check does not apply.
+
+### 5. Categorize by section
+
+The catalog (and its changelog subsection) is determined by the **catalog
+distribution rule** below — the subsection always matches the
+`libs.versions.toml` the change lives in: `versions-androidx/` → **AndroidX**,
+`versions-stack/` → **Stack**, `versions-redmadrobot/` → **red_mad_robot**.
+
+### 6. Add release-notes links
+
+Link each library name to its official release notes, using the exact-version
+anchor/tag where possible:
+
+- **AndroidX:** `https://developer.android.com/jetpack/androidx/releases/{library}#{version}`
+- **Firebase:** `https://firebase.google.com/support/release-notes/android#bom_v{version}`
+- **GitHub projects:** `https://github.com/{org}/{repo}/releases/tag/v{version}`
+
+**Updated dependencies (`:arrow_up:`) — where the URL comes from.** In this
+order:
+
+1. Find the same library's entry in a previous release section of
+   `CHANGELOG.md` and reuse its URL with the new version substituted — this
+   is the default and almost always works.
+2. No previous entry → build the URL from the templates above. Note: the
+   GitHub tag format varies per project — the `v` prefix is not universal
+   (e.g. `dagger-2.60.1`, `r6.1.1`, plain `6.14.0`).
+3. Unsure of the tag format → run
+   `resolve-doc-url.sh <group:artifact> <new-version>` — it works for updates
+   just as well as for new dependencies.
+
+Whichever source you used, the version-presence check in step 9 catches
+mistakes.
+
+**New dependencies (`:sparkle:`) — resolve the link, never invent it.** Do NOT
+guess or construct a URL from a naming pattern — every link must be one you
+actually resolved. Use the script:
+
+```bash
+bash .claude/skills/update-version-catalog/scripts/resolve-doc-url.sh <group:artifact> <version>
+```
+
+It reads the artifact's **HomePage** from its POM (`<url>`/`<scm>`) in Google
+Maven / Maven Central / the Plugin Portal, and if that is a GitHub repository
+queries the GitHub API for the **release or tag matching the version** on that
+page. It prints one verdict:
+
+- `RELEASE <url>` / `TAG <url>` — the GitHub release/tag page for the version;
+  use it directly.
+- `HOMEPAGE <url>` — the POM HomePage (GitHub repo home or a non-GitHub site),
+  found when no per-version release/tag exists. This URL does NOT point at the
+  specific version, so it is **not a valid CHANGELOG link** (see the
+  version-specific link rule below). Do NOT use it as the entry URL — instead
+  show me this URL as the closest match that could be found and ask me to
+  provide the correct version-specific documentation URL myself. Proceed only
+  after I supply a URL (or explicitly confirm the shown one is acceptable).
+- `NO_HOMEPAGE` — the POM has no usable `<url>`/`<scm>` (common for Gradle
+  plugin markers). Fall through to the Plugin Portal route described under
+  "Adding a new dependency" step 5, or search GitHub for the artifact
+  coordinates (`group:artifact`) to locate the source repository.
+- `NOT_FOUND` — the artifact POM is in no repository; STOP and ask me for the URL.
+- `GH_RATE_LIMITED <repo-url>` — the GitHub API rate limit blocked the
+  release/tag lookup. This is NOT "no release exists" — do not fall back to
+  `HOMEPAGE` or ask me for a URL. Set `GITHUB_TOKEN`/`GH_TOKEN` (or wait for
+  the limit to reset) and re-run the script.
+
+**AndroidX libraries** keep the `developer.android.com` release-notes URL
+instead of the script output.
+
+**A documentation link MUST point at the specific version.** A URL that only
+addresses the project/library in general — a repository home, a docs landing
+page, a release-notes index with no version anchor, anything without the exact
+version in its path/anchor/tag — is considered **invalid** as a CHANGELOG link.
+When only such a version-less URL can be found (e.g. the script's `HOMEPAGE`
+verdict), do NOT record it silently: show me the URL that was found and ask me
+to provide the correct version-specific URL myself, proceeding only after I
+supply one (or confirm the shown URL is acceptable).
+
+A link to a Maven artifact page as the CHANGELOG entry itself is FORBIDDEN:
+never use `mvnrepository.com`, `search.maven.org`, `central.sonatype.com`,
+`maven.google.com`, `repo1.maven.org`, or any other repository/artifact listing.
+If the script yields no documentation URL and GitHub search also fails, STOP and
+ask me explicitly to provide the URL for that dependency — do not guess.
+
+### 7. Write entries into `[Unreleased]`
+
+1. Open `CHANGELOG.md`, locate the `## [Unreleased]` section.
+2. Add each entry to the correct subsection (red_mad_robot / AndroidX / Stack).
+3. Format each entry per the rules below.
+4. Sort within each subsection: regular libraries alphabetically first, then
+   `plugin:` entries alphabetically.
+5. Replace `*No changes*` when adding the first entry to a subsection; keep all
+   three subsections present even if some stay `*No changes*`.
+6. No duplicate entries; verify links point to the correct version.
+
+### 8. Fold `CHANGELOG.md` into the single commit
+
+The `CHANGELOG.md` edit must go into the **same commit** as the version bumps —
+do NOT create a separate commit for the changelog alone:
+
+```bash
+bash .claude/skills/update-version-catalog/scripts/commit-release.sh
+```
+
+The script stages `CHANGELOG.md` plus any catalog edits and amends the squashed
+commit from step 3 (or creates the release commit when none exists yet — see
+"Adding a new dependency"). Amend only the commit created by the current
+command — never a commit that pre-dates it (see "Commit rules"). It prints
+`git show HEAD --stat`, which should now list both the
+`versions-*/libs.versions.toml` changes and `CHANGELOG.md` in one commit.
+
+### 9. Validate
+
+**a. Lint the changelog against the release diff:**
+
+```bash
+bash .claude/skills/update-version-catalog/scripts/lint-changelog.sh
+```
+
+Cross-checks the `[Unreleased]` entries against the actual catalog diff and
+the format rules: every catalog change is documented, no phantom entries, exact
+`old` → `new` versions, correct subsection, valid symbols/links/arrow, sorting,
+no duplicates, and that every renovate topic version made it into the diff (a
+`renovate: … not picked` failure is expected only for branches I explicitly
+told you to skip — mention them).
+
+**The `--skip-renovate` flag is decided by the current command, not by the
+commit being linted:**
+
+- the command cherry-picked renovate branches → ALWAYS run without the flag —
+  including when linting the addition commit of a combined update-and-add
+  command;
+- the command cherry-picked nothing (standalone add) → run with
+  `--skip-renovate`, otherwise pending renovate branches would be falsely
+  reported as "not picked".
+
+Fix every reported problem in `CHANGELOG.md`, re-run until it prints `OK`,
+then re-amend with `commit-release.sh`.
+
+**b. Check each release-notes link you added.** For every new `CHANGELOG.md`
+entry, run two checks against its URL:
+
+1. **Reachability** — each URL resolves (HTTP `2xx`, or `3xx` redirect):
+
+   ```bash
+   bash .claude/skills/update-version-catalog/scripts/check-changelog-urls.sh
+   ```
+
+   Lines marked `(redirected to: …)` need attention: some sites redirect
+   missing pages to a generic page and still answer `200` — open the final URL
+   and confirm it is really the release-notes page for that library.
+
+2. **Version presence** — the page actually mentions the entry's **new
+   version**. Fetch the page content (WebFetch, or `curl -sL "$url"`) and search
+   for the new version string from that entry (the one in backticks). Account
+   for format variants (e.g. `2.60` vs `dagger-2.60`, `34.15.0` vs `bom_v34-15-0`,
+   dots vs dashes).
+
+   For `:sparkle:` entries with the default GitHub release/tag link the same
+   check applies. If I explicitly provided a different URL for a new
+   dependency, skip the version-presence check — verify only that the page
+   is reachable and really belongs to that library.
+
+**If a link is unreachable, redirects to an unrelated page, OR the page does
+not contain the new version**, do NOT silently keep it. Show me the problem
+entries — one line each with the library, the new version, and the current
+URL — and offer to find a replacement link (correct anchor/tag, or a different
+release-notes source). Fix the links, re-amend with `commit-release.sh`, and
+re-check before proceeding.
+
+**c. Validate the catalogs:**
+
+```bash
+./gradlew validateCatalog
+```
+
+Confirm the build passes. Report every result plainly — if a link is broken, a
+version is missing from its page, or validation fails, surface it rather than
+claiming success.
+
+### 10. Combined command? — the work is NOT finished yet
+
+STOP before summarising. Re-read the user's request: did it ALSO ask to add
+new dependencies («…и добавь …», "…and add …")? If yes, the update you just
+finished was only **operation 1 of 2** (see the HARD RULE in "Command types").
+Continue immediately with the "Adding a new dependency" flow (steps 2–7 — do
+NOT re-run `start-update.sh`) to produce the separate addition commit. Only
+after that second commit exists and is validated may you report the command as
+done. If the request was update-only, this step is a no-op.
+
+---
+
+## Adding a new dependency
+
+When I give Maven coordinates (`group:artifact`, e.g.
+`org.jetbrains.compose.foundation:foundation`) and ask to add them, the flow
+is: find the latest stable version → add to the right catalog → document →
+one addition commit. This can happen inside a regular update session or
+standalone.
+
+When the same command also asked for an update, finish the update commit first
+(steps 1–9 of the workflow), then do the addition as a **separate commit** on
+top of it — never fold additions into the update commit (see "Commit rules").
+All additions requested by one command share a single addition commit.
+
+1. **Working branch** — same rule as workflow step 1: on `main` or a
+   `dev-update-*` branch run `start-update.sh` (creates/switches to the branch
+   and records the command base); any other branch → STOP and ask. In a
+   combined update-and-add command the update already ran it — do NOT run it
+   again for the addition.
+
+2. **Find the version in Maven:**
+
+   ```bash
+   bash .claude/skills/update-version-catalog/scripts/find-latest-version.sh org.jetbrains.compose.foundation:foundation
+   ```
+
+   `find-latest-version.sh` only accepts `group:artifact`. Which coordinate to
+   pass depends on whether you are adding a **library** or a **Gradle plugin** —
+   tell them apart by how I gave it to you:
+
+   - **Library** (goes in `[libraries]`, given as Maven coordinates
+     `group:artifact`, contains a colon, e.g.
+     `org.jetbrains.compose.foundation:foundation`) → pass those coordinates
+     **verbatim**. Do not transform them.
+   - **Gradle plugin** (goes in `[plugins]`, given as a plugin **id** — a
+     dotted string with **no colon**, e.g. `dev.drewhamilton.poko`,
+     `org.jetbrains.compose`) → you MUST query the plugin's **marker artifact**,
+     whose coordinate is derived mechanically from the id:
+
+     ```
+     <plugin.id>:<plugin.id>.gradle.plugin
+     ```
+
+     i.e. the plugin id is used as BOTH the group and (with the
+     `.gradle.plugin` suffix) the artifact. Worked examples:
+
+     | Plugin id (given) | Coordinate to pass to the script |
+     | ----------------- | -------------------------------- |
+     | `dev.drewhamilton.poko` | `dev.drewhamilton.poko:dev.drewhamilton.poko.gradle.plugin` |
+     | `org.jetbrains.compose` | `org.jetbrains.compose:org.jetbrains.compose.gradle.plugin` |
+     | `com.google.devtools.ksp` | `com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin` |
+
+     NEVER guess a `group:artifact` by splitting the id on the last dot (e.g.
+     `dev.drewhamilton:poko` is **wrong** and will return `NOT_FOUND`). Always
+     build the marker coordinate with the rule above. The marker artifact lives
+     in the Gradle Plugin Portal, which the script already queries.
+
+   Resolve the version to add by these rules, in order. Stable means a plain
+   release with no pre-release qualifier (no `-alpha`, `-beta`, `-rc`, `-M`,
+   `-dev`, `-SNAPSHOT`, etc.).
+
+   - **The latest available version is stable** → take that **latest stable**
+     version and use it without asking.
+   - **A stable version exists, but a newer non-stable version is also
+     available** (e.g. latest stable `1.2.0`, but `1.3.0-beta01` exists) →
+     **STOP and ask me** which of the two to use. Show both — the latest stable
+     and the newer pre-release — so I can pick. Do NOT silently pick either.
+   - **Only non-stable versions exist** (the artifact is published, but every
+     available version is a `beta`/`alpha`/`rc`/other pre-release — the script
+     prints `UNSTABLE`) → **STOP and ask me** which of the available versions
+     to use. Show the candidate versions you found so I can pick one. Do NOT
+     silently pick a pre-release.
+   - **No version is available in Maven at all** (the artifact is not found in
+     any repository) → **STOP and ask me** both which version to specify **and**
+     which documentation URL to use for the CHANGELOG link. Do not guess a
+     version or a link.
+
+   If repositories disagree on the latest version, show me both and ask.
+
+3. **Pick the catalog** strictly by the Maven group per the
+   "Catalog distribution rule" section above: `androidx.*` →
+   `versions-androidx`; `com.redmadrobot.*` → `versions-redmadrobot`;
+   everything else (including `org.jetbrains.compose.*` and
+   `org.jetbrains.androidx.*`) → `versions-stack`. Do not ask which catalog —
+   the rule decides.
+
+4. **Edit that catalog's `libs.versions.toml`:**
+   - `[versions]`: add `alias = "version"`. If the artifact shares a version
+     with already-present artifacts from the same project, reuse their existing
+     version alias instead of adding a new one.
+   - `[libraries]`: add `alias = { module = "group:artifact", version.ref = "alias" }`
+     (for a Gradle plugin use `[plugins]` with `id`).
+   - Follow the naming conventions: alias follows the Maven coordinates, drop
+     module names that duplicate the group, version alias matches the library
+     alias. Keep the file's existing grouping, comments, and alphabetical
+     order within a group.
+   - **Gradle reserved words** (the complete list) — never use `extensions`,
+     `class`, or `convention` as an alias segment, nor `bundles`, `versions`,
+     or `plugins` as the first segment. `./gradlew validateCatalog` (step 9c)
+     is the final safety net for a bad alias.
+   - Worked example — adding the libraries `com.example.avocado:avocado` and
+     `com.example.avocado:avocado-core` `1.2.0` plus the Gradle plugin
+     `dev.drewhamilton.poko` `0.19.3`:
+
+     ```toml
+     [versions]
+     avocado = "1.2.0"   # one shared version alias for the whole project
+     poko = "0.19.3"
+
+     [libraries]
+     # artifact repeats the group's last word → alias keeps only "avocado"
+     avocado = { module = "com.example.avocado:avocado", version.ref = "avocado" }
+     avocado-core = { module = "com.example.avocado:avocado-core", version.ref = "avocado" }
+
+     [plugins]
+     poko = { id = "dev.drewhamilton.poko", version.ref = "poko" }
+     ```
+
+5. **CHANGELOG entry** — a `:sparkle:` line in the matching subsection of
+   `[Unreleased]`, with the version in backticks (see the format reference).
+   Entry name = the library alias; a plugin entry additionally carries the
+   `plugin:` prefix (see the format reference).
+
+   **Resolve the link — never invent it.** Use the script (do NOT construct a
+   URL from a naming pattern):
+
+   ```bash
+   bash .claude/skills/update-version-catalog/scripts/resolve-doc-url.sh <group:artifact> <version>
+   ```
+
+   It reads the artifact's **HomePage** from its POM and, when that is GitHub,
+   finds the **release or tag matching the version** — see workflow step 6 for
+   the full list of verdicts
+   (`RELEASE`/`TAG`/`HOMEPAGE`/`NO_HOMEPAGE`/`NOT_FOUND`/`GH_RATE_LIMITED`). For
+   a **library** pass its Maven coordinates verbatim. For a **Gradle plugin**
+   the marker artifact's POM usually has no HomePage (`NO_HOMEPAGE`) — resolve
+   its repo the plugin way described next.
+
+   **Finding a Gradle plugin's GitHub repo.** A plugin id is NOT its GitHub
+   path — do not turn `dev.drewhamilton.poko` into `github.com/dev.drewhamilton/poko`.
+   Instead open the plugin's Gradle Plugin Portal page, which links to the real
+   source repository:
+
+   ```
+   https://plugins.gradle.org/plugin/<plugin.id>
+   ```
+
+   e.g. `https://plugins.gradle.org/plugin/dev.drewhamilton.poko` →
+   `github.com/drewhamilton/Poko` → release/tag URL for the version. (Web search
+   for "<plugin.id> github" is a fine fallback.)
+
+   The Maven artifact page and the Plugin Portal page are lookup aids only —
+   NEVER put a Maven artifact page (`mvnrepository.com`, `search.maven.org`,
+   `central.sonatype.com`, `maven.google.com`, repo listings) as the entry URL.
+   The link must point at the **specific version** — a version-less URL (repo
+   home, docs landing page, `HOMEPAGE` verdict) is invalid: show me the URL that
+   was found and ask me to provide the correct version-specific one before
+   writing the entry. If none of these steps yield a documentation URL, STOP and
+   ask me to provide the URL for that dependency before writing the entry — do
+   not guess.
+
+6. **Commit:**
+
+   ```bash
+   bash .claude/skills/update-version-catalog/scripts/commit-release.sh "stack: add <alias> <version>"
+   ```
+
+   Standalone add (no update in this command): the script creates the addition
+   commit, and later re-runs (lint/link fixes) amend it. Combined
+   update-and-add command: the update commit already exists — the addition
+   MUST become a **new commit** on top of it; amend only that addition commit
+   afterwards, never the update commit or anything older (see "Commit rules").
+
+7. **Validate as in workflow step 9.** The `--skip-renovate` rule from there
+   applies: standalone add command (nothing cherry-picked) →
+   `lint-changelog.sh --skip-renovate`; combined update-and-add command →
+   WITHOUT the flag, also when linting the addition commit.
+
+---
+
+## CHANGELOG.md format reference
+
+### Symbol legend
+
+| Symbol       | Meaning                                                              |
+| ------------ | -------------------------------------------------------------------- |
+| `:sparkle:`  | Added dependency                                                     |
+| `:arrow_up:` | Updated dependency                                                   |
+| `:x:`        | Removed dependency                                                   |
+| `:memo:`     | Dependency or version name changed                                   |
+| `:warning:`  | Be careful on update. May contain breaking or behaviour changes.     |
+
+`:warning:` is NOT set by this skill — deciding whether an update is breaking
+requires reading the dependency's release notes, which is out of scope here.
+The maintainer adds it manually where needed; preserve any existing `:warning:`
+marks when editing entries.
+
+### File structure
+
+- **Header** — symbol legend.
+- **`## [Unreleased]`** — changes not yet released, with the three subsections
+  `### red_mad_robot`, `### AndroidX`, `### Stack`.
+- **Version sections** — `## [YYYY.MM.DD]`, each with the same three subsections.
+- **Footer links** — previous-year changelogs and GitHub compare links per version.
+
+### Entry format
+
+```markdown
+# New dependency — link the library's GitHub release/tag page for the version;
+# never a Maven artifact page (ask the user if no GitHub page can be found)
+- :sparkle: [library-name](github-release-or-tag-url) `version`
+
+# Updated dependency
+- :arrow_up: [library-name](release-notes-url) `old-version` → `new-version`
+
+# Removed dependency
+- :x: [library-name](release-notes-url)
+
+# Renamed / changed
+- :memo: [library-name](release-notes-url) description
+
+# Plugin — prefix with `plugin:`
+- :arrow_up: plugin: [Plugin Name](url) `old-version` → `new-version`
+```
+
+Use the real arrow `→` (never `->`). Wrap version numbers in backticks.
+
+### Sorting within a subsection
+
+1. Regular libraries — alphabetically by name.
+2. Plugins (`plugin:` prefix) — alphabetically by name.
+3. If no changes: `- *No changes*`.
+
+### Common patterns
+
+**BOM updates** — list individual component bumps nested under the BOM entry:
+
+```markdown
+- :arrow_up: [compose-bom](url) `2025.10.00` → `2025.11.01`
+  - :arrow_up: [compose-animation](url) `1.9.3` → `1.9.5`
+  - :arrow_up: [compose-foundation](url) `1.9.3` → `1.9.5`
+```
+
+The catalog diff contains only the BOM's own version — the component versions
+are NOT in it. Take them from the BOM's version-mapping / release-notes page
+(for `compose-bom`:
+<https://developer.android.com/develop/ui/compose/bom/bom-mapping> — compare
+the old and the new BOM mapping and list the libraries whose versions
+changed). Each nested component links to its own release notes (for AndroidX —
+the usual `developer.android.com/jetpack/androidx/releases/…` URL with the
+component's version anchor).
+
+**Monorepo updates** — each library from the same repo gets its own entry:
+
+```markdown
+- :arrow_up: [okhttp](url) `5.2.1` → `5.3.2`
+- :arrow_up: [okhttp-logging-interceptor](url) `5.2.1` → `5.3.2`
+```
+
+**Catalog name changes** — use the memo symbol:
+
+```markdown
+- :memo: [library-name](url) Renamed from old-name to new-name
+```
+
+### Quality checklist
+
+- [ ] Every entry has the correct emoji symbol.
+- [ ] Library names are links to release notes; `:sparkle:` entries link to
+      the library's GitHub release/tag page (or a URL explicitly provided by
+      the user) — never to a Maven artifact page.
+- [ ] Version numbers wrapped in backticks.
+- [ ] Arrow `→` used (not `->`).
+- [ ] Existing `:warning:` marks preserved (never added by this skill).
+- [ ] Entries sorted alphabetically (libraries first, then plugins).
+- [ ] Plugins have `plugin:` prefix.
+- [ ] No duplicate entries.
+- [ ] All three subsections present (even if `*No changes*`).
+- [ ] Links valid and point to the correct version.
+
+### What NOT to record
+
+Do **not** add to the changelog:
+- Gradle wrapper updates.
+- GitHub Actions / CI-CD workflow changes.
+- Documentation-only changes.
+- Internal build-script modifications.
+- Config-file changes that don't affect dependencies.
+
+---
+
+## Out of scope
+
+This skill records changes into `[Unreleased]`. Cutting an actual release
+(moving `[Unreleased]` into a dated `## [YYYY.MM.DD]` section, bumping
+`gradle.properties`, updating footer compare links, tagging) is done by
+`./release.sh` — do not do it here unless the user explicitly asks to release.

--- a/.claude/skills/update-version-catalog/scripts/check-changelog-urls.sh
+++ b/.claude/skills/update-version-catalog/scripts/check-changelog-urls.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Reachability check for release-notes URLs added to CHANGELOG.md in the current
+# release commit. Prints "HTTP_CODE  URL" per unique added URL. When the final
+# URL after redirects differs from the requested one, it is appended as
+# "(redirected to: …)" — a redirect landing on a different page usually means
+# the requested page is wrong or gone (some sites redirect missing pages to a
+# generic page and answer 200), so verify such links.
+#
+# NOTE: this covers step 9b check #1 (reachability) only. The version-presence
+# check (does the page mention the new version?) is done by the agent via
+# WebFetch — see SKILL.md step 9.
+#
+# READ-ONLY. Usage: bash check-changelog-urls.sh
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+urls=$(git show HEAD -- CHANGELOG.md \
+  | grep -E '^\+' \
+  | grep -oE 'https?://[^)[:space:]]+' \
+  | sort -u || true)
+
+if [ -z "$urls" ]; then
+  echo "No URLs added to CHANGELOG.md in HEAD — nothing to check."
+  exit 0
+fi
+
+while read -r url; do
+  # `|| res=…` keeps the loop going on network errors (DNS, timeout, …);
+  # it must REPLACE, not append — on failure curl still emits its own -w output.
+  res=$(curl -s -o /dev/null -L --max-time 15 -w '%{http_code} %{url_effective}' "$url") || res="000 $url"
+  code="${res%% *}"; final="${res#* }"
+  # compare without fragments — they are client-side only and curl keeps the
+  # requested one in url_effective even when nothing redirected
+  final="${final%%#*}"; req="${url%%#*}"
+  if [ "${final%/}" != "${req%/}" ]; then
+    echo "$code  $url  (redirected to: $final)"
+  else
+    echo "$code  $url"
+  fi
+done <<< "$urls"

--- a/.claude/skills/update-version-catalog/scripts/cherry-pick-renovate.sh
+++ b/.claude/skills/update-version-catalog/scripts/cherry-pick-renovate.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Cherry-pick renovate branches onto the current working branch.
+#
+#   bash cherry-pick-renovate.sh                 # ALL origin/renovate/* ahead of origin/main
+#   bash cherry-pick-renovate.sh dagger kotest   # only the named ones
+#
+# Accepts short names (dagger), renovate/dagger, or origin/renovate/dagger.
+# Picks EVERY commit a branch has ahead of origin/main (not just its tip).
+# Commits already applied to HEAD (by patch-id) are skipped individually, so
+# the script is safe to re-run after a conflict was resolved.
+#
+# SAFETY: refuses to run unless HEAD is a dev-update-* branch. On a conflict it
+# stops (git leaves the cherry-pick in progress) so it can be resolved manually,
+# then simply re-run it — already-picked branches are skipped.
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+cur=$(git branch --show-current)
+case "$cur" in
+  dev-update-*) ;;
+  *) echo "ERROR: not on a dev-update-* branch (on '$cur'). Aborting."; exit 1 ;;
+esac
+
+if [ "$#" -gt 0 ]; then
+  inputs=("$@")
+else
+  inputs=()
+  for b in $(git for-each-ref --format='%(refname:short)' 'refs/remotes/origin/renovate/*'); do
+    [ "$(git rev-list --count "origin/main..$b")" -gt 0 ] && inputs+=("$b")
+  done
+fi
+
+[ "${#inputs[@]}" -eq 0 ] && { echo "Nothing to cherry-pick."; exit 0; }
+
+for b in "${inputs[@]}"; do
+  case "$b" in
+    origin/*)   ref="$b" ;;
+    renovate/*) ref="origin/$b" ;;
+    *)          ref="origin/renovate/$b" ;;
+  esac
+  # Commits of $ref (vs origin/main) not yet in HEAD by patch-id, oldest first.
+  to_pick=$(git cherry HEAD "$ref" origin/main | awk '$1 == "+" { print $2 }')
+  if [ -z "$to_pick" ]; then
+    echo ">>> skip $ref (already applied)"
+    continue
+  fi
+  echo ">>> cherry-pick $ref"
+  # shellcheck disable=SC2086 — intentional word splitting, one SHA per word
+  git cherry-pick $to_pick
+done
+
+echo
+echo "Commits now on $cur (vs origin/main):"
+git log --oneline "origin/main..HEAD"

--- a/.claude/skills/update-version-catalog/scripts/commit-release.sh
+++ b/.claude/skills/update-version-catalog/scripts/commit-release.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# Create or amend the current command's release commit with the catalog and
+# CHANGELOG.md changes.
+#
+#   bash commit-release.sh            # amend HEAD — update flow (fold the
+#                                     # CHANGELOG into the squashed commit) and
+#                                     # re-runs after lint/link fixes
+#   bash commit-release.sh "message"  # NEW commit with this message — addition
+#                                     # flow; if HEAD already has exactly this
+#                                     # subject, it is amended instead
+#                                     # (idempotent re-runs)
+#
+# SAFETY: refuses to run unless HEAD is a dev-update-* branch; never amends a
+# commit reachable from origin/main, a release commit ("version: …"), or a
+# commit at or below the command base recorded by start-update.sh (i.e. a
+# commit created before the current command).
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+cur=$(git branch --show-current)
+case "$cur" in
+  dev-update-*) ;;
+  *) echo "ERROR: not on a dev-update-* branch (on '$cur'). Aborting."; exit 1 ;;
+esac
+
+git add -- CHANGELOG.md 'versions-*/libs.versions.toml'
+
+msg="${1:-}"
+head_subject=$(git log -1 --format=%s HEAD)
+
+if [ -n "$msg" ] && [ "$head_subject" != "$msg" ]; then
+  # addition flow: new commit on top (never mixed into the update commit)
+  if git diff --cached --quiet; then
+    echo "ERROR: nothing staged — no catalog/CHANGELOG changes to commit."; exit 1
+  fi
+  git commit -m "$msg"
+else
+  # amend flow — only the commit created by the current command
+  if git merge-base --is-ancestor HEAD origin/main; then
+    echo "ERROR: HEAD is on origin/main — nothing to amend. Pass a message to create a commit."
+    exit 1
+  fi
+  case "$head_subject" in
+    version:*) echo "ERROR: HEAD is a release commit ('$head_subject') — refusing to amend."; exit 1 ;;
+  esac
+  base_file="$(git rev-parse --git-dir)/update-catalog-base"
+  if [ -f "$base_file" ]; then
+    read -r mbranch msha < "$base_file" || true
+    if [ "${mbranch:-}" = "$cur" ] && git cat-file -e "${msha:-}^{commit}" 2>/dev/null \
+       && git merge-base --is-ancestor HEAD "$msha"; then
+      echo "ERROR: HEAD pre-dates the current command's base ($(git log --oneline -1 "$msha"))."
+      echo "Refusing to amend an earlier command's commit — pass a message to create a new one."
+      exit 1
+    fi
+  fi
+  if git diff --cached --quiet; then
+    echo "Nothing staged — HEAD left unchanged."
+  else
+    git commit --amend --no-edit
+  fi
+fi
+
+echo
+git show HEAD --stat --format=oneline

--- a/.claude/skills/update-version-catalog/scripts/find-latest-version.sh
+++ b/.claude/skills/update-version-catalog/scripts/find-latest-version.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# Find the latest version of Maven artifacts in Google Maven, Maven Central
+# and the Gradle Plugin Portal.
+#
+#   bash find-latest-version.sh group:artifact [group:artifact ...]
+#
+# For a Gradle plugin pass its marker artifact:
+#   <plugin.id>:<plugin.id>.gradle.plugin
+#
+# Per artifact prints one line per repository that has it (latest and latest
+# stable version), then a verdict line:
+#   LATEST_STABLE <v>                     latest available version is stable
+#   STABLE <v> NEWER_PRERELEASE <v>       stable exists, but a pre-release with a
+#                                         genuinely NEWER base version too — ask
+#                                         the user. Pre-releases of the stable
+#                                         version itself (or older) do not count.
+#   UNSTABLE candidates: <v…>             only pre-release versions exist — ask the user
+#   NOT_FOUND                             artifact is in no repository — ask the user
+#
+# Stable = no pre-release qualifier (alpha/beta/rc/M/dev/eap/snapshot/preview/cr).
+# READ-ONLY.
+set -euo pipefail
+
+[ "$#" -ge 1 ] || { echo "Usage: bash find-latest-version.sh <group:artifact>…"; exit 1; }
+
+PRE_RE='(alpha|beta|rc|snapshot|dev|eap|preview|milestone|[-.]M[0-9]|[-.]cr[0-9]?)'
+
+stable_only() { grep -ivE "$PRE_RE" || true; }
+
+fetch_versions() { # $1 = repo base url, $2 = group, $3 = artifact
+  curl -sfL --max-time 20 "$1/${2//./\/}/$3/maven-metadata.xml" 2>/dev/null \
+    | grep -oE '<version>[^<]+</version>' \
+    | sed -E 's#</?version>##g' || true
+}
+
+status=0
+for coord in "$@"; do
+  group="${coord%%:*}"; artifact="${coord#*:}"
+  if [ -z "$group" ] || [ -z "$artifact" ] || [ "$group" = "$coord" ]; then
+    echo "ERROR: '$coord' is not of the form group:artifact"; status=1; continue
+  fi
+  echo "=== $coord"
+
+  combined=""
+  while read -r name base; do
+    versions=$(fetch_versions "$base" "$group" "$artifact")
+    [ -n "$versions" ] || continue
+    latest=$(sort -V <<< "$versions" | tail -1)
+    stable=$(stable_only <<< "$versions" | sort -V | tail -1)
+    echo "  $name: latest=$latest latest_stable=${stable:-<none>}"
+    combined+="$versions"$'\n'
+  done <<'EOF'
+google         https://dl.google.com/android/maven2
+maven-central  https://repo1.maven.org/maven2
+plugin-portal  https://plugins.gradle.org/m2
+EOF
+
+  if [ -z "$combined" ]; then
+    echo "  NOT_FOUND"
+    status=1
+    continue
+  fi
+
+  all=$(sort -uV <<< "$combined" | sed '/^$/d')
+  best_any=$(tail -1 <<< "$all")
+  best_stable=$(stable_only <<< "$all" | tail -1)
+
+  if [ -z "$best_stable" ]; then
+    echo "  UNSTABLE candidates: $(tail -8 <<< "$all" | tr '\n' ' ')"
+  elif [ "$best_stable" = "$best_any" ]; then
+    echo "  LATEST_STABLE $best_stable"
+  else
+    # sort -V puts `X-rc1` AFTER `X`, so best_any may be a pre-release of the
+    # stable version itself (or of an older one) — that is not "newer". Only a
+    # pre-release whose leading numeric base exceeds best_stable counts.
+    base_any=$(grep -oE '^[0-9]+(\.[0-9]+)*' <<< "$best_any" || true)
+    if [ -n "$base_any" ] \
+       && [ "$(printf '%s\n%s\n' "$best_stable" "$base_any" | sort -V | tail -1)" = "$best_stable" ]; then
+      echo "  LATEST_STABLE $best_stable"
+    else
+      echo "  STABLE $best_stable NEWER_PRERELEASE $best_any"
+    fi
+  fi
+done
+exit "$status"

--- a/.claude/skills/update-version-catalog/scripts/lint-changelog.sh
+++ b/.claude/skills/update-version-catalog/scripts/lint-changelog.sh
@@ -1,0 +1,337 @@
+#!/usr/bin/env bash
+#
+# Cross-check the [Unreleased] section of CHANGELOG.md against the actual
+# catalog changes of the working branch (origin/main..HEAD) and the format
+# rules from SKILL.md:
+#
+#   - every catalog version change is documented in the right subsection with
+#     exact `old` → `new` versions; added deps have :sparkle:, removed :x:;
+#   - no phantom entries (documenting a change that is not in the diff);
+#   - valid symbols, markdown links, real arrow "→" (never "->"), versions in
+#     backticks, plugin: prefix format;
+#   - sorting (libraries alphabetically, then plugin: entries alphabetically;
+#     nested BOM-component entries sorted within their parent),
+#     no duplicates, all three subsections present, no stray "*No changes*";
+#   - every renovate branch's topic version made it into the branch diff
+#     (skip with --skip-renovate in add-only sessions).
+#
+# Prints PROBLEM lines and exits 1, or prints OK. INFO lines are advisory.
+# READ-ONLY. Usage: bash lint-changelog.sh [--skip-renovate]
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+skip_renovate=0
+[ "${1:-}" = "--skip-renovate" ] && skip_renovate=1
+
+problems=()
+problem() { problems+=("$1"); }
+info() { echo "INFO: $1"; }
+
+norm() { local s="${1,,}"; echo "${s//[^a-z0-9]/}"; }
+
+# ---------- catalog changes on the branch (origin/main..HEAD) ---------------
+
+declare -A OLDV NEWV            # "<sub>|<alias>" -> version
+declare -A CHG_OLD CHG_NEW      # updated aliases
+declare -A ADDEDV REMOVEDV      # added / removed aliases
+declare -A DIFF_ADD DIFF_DEL    # per subsection: raw added/removed diff lines
+
+sub_of_dir() {
+  case "$1" in
+    versions-androidx)    echo "AndroidX" ;;
+    versions-redmadrobot) echo "red_mad_robot" ;;
+    versions-stack)       echo "Stack" ;;
+    *)                    echo "" ;;
+  esac
+}
+
+versions_map() { # $1=rev $2=file -> "alias<TAB>version" lines from [versions]
+  git show "$1:$2" 2>/dev/null \
+    | sed -nE '/^\[versions\]/,/^\[(libraries|plugins|bundles)\]/p' \
+    | sed -nE 's/^([A-Za-z0-9_.-]+)[[:space:]]*=[[:space:]]*"([^"]+)".*$/\1\t\2/p'
+}
+
+for f in versions-*/libs.versions.toml; do
+  sub=$(sub_of_dir "${f%%/*}"); [ -n "$sub" ] || continue
+  while IFS=$'\t' read -r a v; do
+    [ -n "$a" ] && OLDV["$sub|$a"]="$v"
+  done < <(versions_map origin/main "$f")
+  while IFS=$'\t' read -r a v; do
+    [ -n "$a" ] && NEWV["$sub|$a"]="$v"
+  done < <(versions_map HEAD "$f")
+  DIFF_ADD["$sub"]=$(git diff origin/main..HEAD -- "$f" | grep -E '^\+[^+]' || true)
+  DIFF_DEL["$sub"]=$(git diff origin/main..HEAD -- "$f" | grep -E '^-[^-]' || true)
+done
+
+for k in "${!NEWV[@]}"; do
+  if [ "${OLDV[$k]+x}" = x ]; then
+    if [ "${OLDV[$k]}" != "${NEWV[$k]}" ]; then
+      CHG_OLD["$k"]="${OLDV[$k]}"; CHG_NEW["$k"]="${NEWV[$k]}"
+    fi
+  else
+    ADDEDV["$k"]="${NEWV[$k]}"
+  fi
+done
+for k in "${!OLDV[@]}"; do
+  [ "${NEWV[$k]+x}" = x ] || REMOVEDV["$k"]="${OLDV[$k]}"
+done
+
+# ---------- [Unreleased] entries ---------------------------------------------
+
+unreleased() { # $1=rev
+  git show "$1:CHANGELOG.md" 2>/dev/null | awk '
+    /^## \[Unreleased\]/ {u=1; next}
+    /^## \[/ {u=0}
+    u {print}
+  '
+}
+
+annotate() { # stdin -> "sub<TAB>indent<TAB>entry-line"
+  awk '
+    /^### /  {s=substr($0,5); next}
+    s=="" {next}
+    /^- /    {print s "\t0\t" $0}
+    /^  - /  {print s "\t1\t" $0}
+  '
+}
+
+head_unrel=$(unreleased HEAD)
+main_unrel=$(unreleased origin/main)
+[ -n "$head_unrel" ] || { echo "PROBLEM: no [Unreleased] section in CHANGELOG.md"; exit 1; }
+
+head_ann=$(annotate <<< "$head_unrel")
+main_ann=$(annotate <<< "$main_unrel")
+if [ -n "$main_ann" ]; then
+  new_ann=$(grep -Fxv -f <(printf '%s\n' "$main_ann") <<< "$head_ann" || true)
+else
+  new_ann="$head_ann"
+fi
+
+entry_name() { sed -nE 's/^ *- :[a-z_]+: (plugin: )?\[([^]]+)\].*$/\2/p' <<< "$1"; }
+entry_sym()  { sed -nE 's/^ *- :([a-z_]+):.*$/\1/p' <<< "$1"; }
+entry_vers() { grep -oE '`[^`]+`' <<< "$1" | tr -d '`' || true; }
+
+# ---------- structural checks -------------------------------------------------
+
+for s in red_mad_robot AndroidX Stack; do
+  if ! grep -q "^### $s\$" <<< "$head_unrel"; then
+    problem "missing subsection '### $s' in [Unreleased]"
+    continue
+  fi
+  body=$(awk -v s="### $s" '$0==s{f=1;next} /^### /{f=0} f' <<< "$head_unrel")
+  n_entries=$(grep -cE '^ *- :' <<< "$body" || true)
+  n_nochange=$(grep -cF '*No changes*' <<< "$body" || true)
+  if [ "$n_entries" -gt 0 ] && [ "$n_nochange" -gt 0 ]; then
+    problem "subsection $s: has entries but still contains '*No changes*'"
+  fi
+  if [ "$n_entries" -eq 0 ] && [ "$n_nochange" -eq 0 ]; then
+    problem "subsection $s: empty — add '- *No changes*'"
+  fi
+done
+
+dups=$(grep -E '^ *- :' <<< "$head_unrel" | sort | uniq -d || true)
+if [ -n "$dups" ]; then
+  while IFS= read -r d; do [ -n "$d" ] && problem "duplicate entry: $d"; done <<< "$dups"
+fi
+
+# ---------- per-entry format + cross-check ------------------------------------
+
+while IFS=$'\t' read -r sub indent line; do
+  [ -n "$line" ] || continue
+
+  if grep -qF -- '->' <<< "$line"; then
+    problem "uses '->' instead of '→': $line"
+  fi
+
+  sym=$(entry_sym "$line")
+  name=$(entry_name "$line")
+  case "$sym" in
+    arrow_up) re='^(  )?- :arrow_up: (plugin: )?\[[^]]+\]\([^)]+\) `[^`]+` → `[^`]+`( :warning:)?$' ;;
+    sparkle)  re='^(  )?- :sparkle: (plugin: )?\[[^]]+\]\([^)]+\) `[^`]+`( :warning:)?$' ;;
+    x)        re='^(  )?- :x: (plugin: )?\[[^]]+\]\([^)]+\)( :warning:)?$' ;;
+    memo)     re='^(  )?- :memo: (plugin: )?\[[^]]+\]\([^)]+\) .+$' ;;
+    *)        problem "unknown/missing symbol: $line"; continue ;;
+  esac
+  if ! grep -qE "$re" <<< "$line"; then
+    problem "bad $sym entry format: $line"
+    continue
+  fi
+
+  # diff cross-check — top-level entries only (nested = BOM components)
+  [ "$indent" = "0" ] || continue
+  key="$sub|$name"
+  case "$sym" in
+    arrow_up)
+      old=$(sed -n 1p <<< "$(entry_vers "$line")")
+      new=$(sed -n 2p <<< "$(entry_vers "$line")")
+      matched=""
+      if [ "${CHG_OLD[$key]+x}" = x ]; then
+        matched="$key"
+      else
+        for k in "${!CHG_OLD[@]}"; do
+          [ "${k%%|*}" = "$sub" ] || continue
+          [ "$(norm "${k#*|}")" = "$(norm "$name")" ] && { matched="$k"; break; }
+        done
+      fi
+      if [ -n "$matched" ]; then
+        if [ "${CHG_OLD[$matched]}" != "$old" ] || [ "${CHG_NEW[$matched]}" != "$new" ]; then
+          problem "$sub/$name: entry says \`$old\` → \`$new\` but diff says ${CHG_OLD[$matched]} → ${CHG_NEW[$matched]}"
+        fi
+      else
+        pair=0
+        for k in "${!CHG_OLD[@]}"; do
+          [ "${k%%|*}" = "$sub" ] && [ "${CHG_OLD[$k]}" = "$old" ] && [ "${CHG_NEW[$k]}" = "$new" ] && { pair=1; break; }
+        done
+        if [ "$pair" -eq 0 ]; then
+          if [ "${OLDV[$key]+x}" = x ] || [ "${NEWV[$key]+x}" = x ]; then
+            problem "$sub/$name: phantom entry — alias exists but \`$old\` → \`$new\` is not in the branch diff"
+          else
+            info "$sub/$name: no matching version alias — not cross-checked (BOM component?)"
+          fi
+        fi
+      fi
+      ;;
+    sparkle)
+      v=$(sed -n 1p <<< "$(entry_vers "$line")")
+      if [ "${ADDEDV[$key]+x}" = x ]; then
+        [ "${ADDEDV[$key]}" = "$v" ] \
+          || problem "$sub/$name: entry says \`$v\` but added alias has ${ADDEDV[$key]}"
+      elif grep -qF "\"$v\"" <<< "${DIFF_ADD[$sub]:-}"; then
+        : # version literal present in the added diff lines
+      elif grep -qiF "$name" <<< "${DIFF_ADD[$sub]:-}"; then
+        : # library added reusing an existing version alias
+      else
+        problem "$sub/$name: :sparkle: entry but nothing matching added in $sub catalog diff"
+      fi
+      ;;
+    x)
+      matched=0
+      if [ "${REMOVEDV[$key]+x}" = x ]; then
+        matched=1
+      else
+        for k in "${!REMOVEDV[@]}"; do
+          [ "${k%%|*}" = "$sub" ] || continue
+          [ "$(norm "${k#*|}")" = "$(norm "$name")" ] && { matched=1; break; }
+        done
+        grep -qiF "$name" <<< "${DIFF_DEL[$sub]:-}" && matched=1
+      fi
+      [ "$matched" -eq 1 ] \
+        || problem "$sub/$name: :x: entry but nothing matching removed in $sub catalog diff"
+      ;;
+  esac
+done <<< "$new_ann"
+
+# ---------- coverage: every catalog change must be documented ------------------
+
+find_entry() { # $1=sub $2=grep-pattern (fixed string) -> 0 if some new entry matches
+  while IFS=$'\t' read -r es ei el; do
+    [ -n "$el" ] || continue
+    [ "$es" = "$1" ] || continue
+    grep -qF -- "$2" <<< "$el" && return 0
+  done <<< "$new_ann"
+  return 1
+}
+
+find_entry_by_name() { # $1=sub $2=alias
+  while IFS=$'\t' read -r es ei el; do
+    [ -n "$el" ] || continue
+    [ "$es" = "$1" ] || continue
+    en=$(entry_name "$el")
+    [ -n "$en" ] && [ "$(norm "$en")" = "$(norm "$2")" ] && return 0
+  done <<< "$new_ann"
+  return 1
+}
+
+for k in "${!CHG_OLD[@]}"; do
+  sub="${k%%|*}"; a="${k#*|}"
+  find_entry "$sub" "\`${CHG_OLD[$k]}\` → \`${CHG_NEW[$k]}\`" && continue
+  find_entry_by_name "$sub" "$a" && continue
+  problem "not documented: $sub $a ${CHG_OLD[$k]} → ${CHG_NEW[$k]}"
+done
+for k in "${!ADDEDV[@]}"; do
+  sub="${k%%|*}"; a="${k#*|}"
+  find_entry "$sub" "\`${ADDEDV[$k]}\`" && continue
+  find_entry_by_name "$sub" "$a" && continue
+  problem "not documented (added): $sub $a ${ADDEDV[$k]}"
+done
+for k in "${!REMOVEDV[@]}"; do
+  sub="${k%%|*}"; a="${k#*|}"
+  find_entry_by_name "$sub" "$a" \
+    || problem "not documented (removed): $sub $a — needs a :x: or :memo: entry"
+done
+
+# ---------- sorting -------------------------------------------------------------
+
+# nested (BOM-component) entries must be sorted within their parent entry
+check_nested() { # uses/clears $nested, reports against $s/$parent
+  [ -n "$nested" ] || return 0
+  if ! LC_ALL=C sort -fc <<< "${nested%$'\n'}" 2>/dev/null; then
+    problem "$s: nested entries under '$parent' are not sorted alphabetically"
+  fi
+  nested=""
+}
+
+for s in red_mad_robot AndroidX Stack; do
+  body=$(awk -v s="### $s" '$0==s{f=1;next} /^### /{f=0} f' <<< "$head_unrel")
+  libs=""; plugs=""; seen_plug=0; parent=""; nested=""
+  while IFS= read -r line; do
+    if grep -qE '^  - :' <<< "$line"; then
+      n=$(entry_name "$line"); [ -n "$n" ] && nested+="$n"$'\n'
+      continue
+    fi
+    check_nested
+    grep -qE '^- :' <<< "$line" || continue
+    n=$(entry_name "$line"); [ -n "$n" ] || continue
+    parent="$n"
+    if grep -qE '^- :[a-z_]+: plugin: ' <<< "$line"; then
+      seen_plug=1; plugs+="$n"$'\n'
+    else
+      [ "$seen_plug" -eq 1 ] && problem "$s: library entry after plugin entries: $line"
+      libs+="$n"$'\n'
+    fi
+  done <<< "$body"
+  check_nested
+  for group in libs plugs; do
+    names="${!group}"
+    names="${names%$'\n'}"   # <<< would add an empty last line otherwise
+    [ -n "$names" ] || continue
+    if ! LC_ALL=C sort -fc <<< "$names" 2>/dev/null; then
+      problem "$s: ${group%s} entries are not sorted alphabetically"
+    fi
+  done
+done
+
+# ---------- renovate branches picked --------------------------------------------
+
+if [ "$skip_renovate" -eq 0 ]; then
+  branch_added=$(git diff origin/main..HEAD | grep -E '^\+[^+]' || true)
+  for b in $(git for-each-ref --format='%(refname:short)' 'refs/remotes/origin/renovate/*' | sort); do
+    [ "$(git rev-list --count "origin/main..$b")" -gt 0 ] || continue
+    short="${b#origin/renovate/}"
+    versions=$(git log --format='%s' "origin/main..$b" \
+      | awk '{t=$NF} t ~ /[0-9]/ {sub(/^v/,"",t); print t}' | sort -u)
+    if [ -n "$versions" ]; then
+      while IFS= read -r v; do
+        [ -n "$v" ] || continue
+        grep -qF -- "$v" <<< "$branch_added" \
+          || problem "renovate: $short not picked (version $v not in branch diff)"
+      done <<< "$versions"
+    else
+      picked=0
+      while IFS= read -r l; do
+        [ -n "$l" ] || continue
+        grep -qF -- "$l" <<< "$branch_added" && { picked=1; break; }
+      done <<< "$(git diff "origin/main...$b" | grep -E '^\+[^+]' | grep -vE '^\+\s*$' | head -50 || true)"
+      [ "$picked" -eq 1 ] || problem "renovate: $short not picked (no topic version; none of its changes found in branch diff)"
+    fi
+  done
+fi
+
+# ---------- report ---------------------------------------------------------------
+
+if [ "${#problems[@]}" -eq 0 ]; then
+  echo "OK"
+else
+  for p in "${problems[@]}"; do echo "PROBLEM: $p"; done
+  exit 1
+fi

--- a/.claude/skills/update-version-catalog/scripts/list-renovate-updates.sh
+++ b/.claude/skills/update-version-catalog/scripts/list-renovate-updates.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Fetch and list every origin/renovate/* branch that has commits ahead of
+# origin/main: branch name, commit topics, catalog version changes and any
+# other touched files.
+#
+# READ-ONLY (only fetches from origin). Usage: bash list-renovate-updates.sh
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+git fetch --prune origin >/dev/null 2>&1 \
+  || echo "WARNING: git fetch failed — listing may be stale." >&2
+
+found=0
+for b in $(git for-each-ref --format='%(refname:short)' 'refs/remotes/origin/renovate/*' | sort); do
+  [ "$(git rev-list --count "origin/main..$b")" -gt 0 ] || continue
+  found=1
+  echo "=== ${b#origin/renovate/}"
+  git log --format='    %h %s' "origin/main..$b"
+  # catalog version changes (vs merge-base, so an outdated base does not show
+  # unrelated changes)
+  cat_diff=$(git diff "origin/main...$b" -- 'versions-*/libs.versions.toml' \
+    | grep -E '^(diff --git|[-+][^-+])' || true)
+  if [ -n "$cat_diff" ]; then
+    echo "  catalog changes:"
+    sed 's/^/    /' <<< "$cat_diff"
+  fi
+  other=$(git diff --name-only "origin/main...$b" -- . ':!versions-*/libs.versions.toml' || true)
+  if [ -n "$other" ]; then
+    echo "  other changed files:"
+    sed 's/^/    /' <<< "$other"
+  fi
+  echo
+done
+
+[ "$found" -eq 1 ] || echo "No renovate branches ahead of origin/main."

--- a/.claude/skills/update-version-catalog/scripts/resolve-doc-url.sh
+++ b/.claude/skills/update-version-catalog/scripts/resolve-doc-url.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+#
+# Resolve the documentation URL for a newly added dependency — never invent it.
+#
+#   bash resolve-doc-url.sh <group:artifact> <version>
+#
+# For a Gradle plugin pass its marker artifact:
+#   <plugin.id>:<plugin.id>.gradle.plugin
+#
+# Resolution order (matches SKILL.md step 6 / "Adding a new dependency" step 5):
+#   1. Read the HomePage of the artifact from its POM (<url>, falling back to
+#      <scm><url>) in Google Maven / Maven Central / the Gradle Plugin Portal.
+#   2. If the HomePage is a GitHub repository, query the GitHub API for a
+#      RELEASE or TAG whose name matches <version> (accepting a leading `v` and
+#      any `name-`/`name_`/`name/` prefix, e.g. `v1.11.1`, `dagger-2.60`,
+#      `lifecycle-viewmodel-compose-2.10.0`) and print that release/tag page.
+#   3. If no matching release/tag exists, print the repository HomePage itself.
+#   4. If the HomePage is not GitHub, print it verbatim.
+#
+# Prints one verdict line:
+#   RELEASE   <url>   github release page for the version (best)
+#   TAG       <url>   github tag page for the version
+#   HOMEPAGE  <url>   repo/home page, no per-version release or tag found
+#   NO_HOMEPAGE      POM has no <url>/<scm> (common for plugin markers — use
+#                    the Gradle Plugin Portal route in SKILL.md, then re-run
+#                    with the real group:artifact)
+#   NOT_FOUND        artifact POM is in no repository
+#   GH_RATE_LIMITED <repo-url>   the GitHub API rate limit blocked the
+#                    release/tag lookup — NOT the same as "no release exists";
+#                    set GITHUB_TOKEN/GH_TOKEN (or wait) and re-run
+#
+# A GitHub token in $GITHUB_TOKEN / $GH_TOKEN is used if present (higher rate
+# limit) but is not required. READ-ONLY.
+set -euo pipefail
+
+[ "$#" -eq 2 ] || { echo "Usage: bash resolve-doc-url.sh <group:artifact> <version>"; exit 1; }
+
+coord="$1"; version="$2"
+group="${coord%%:*}"; artifact="${coord#*:}"
+if [ -z "$group" ] || [ -z "$artifact" ] || [ "$group" = "$coord" ]; then
+  echo "ERROR: '$coord' is not of the form group:artifact"; exit 1
+fi
+
+# --- 1. fetch the POM and read its HomePage --------------------------------
+fetch_pom() { # $1 = repo base url
+  curl -sfL --max-time 20 \
+    "$1/${group//./\/}/$artifact/$version/$artifact-$version.pom" 2>/dev/null || true
+}
+
+pom=""
+while read -r _name base; do
+  pom=$(fetch_pom "$base")
+  [ -n "$pom" ] && break
+done <<'EOF'
+google         https://dl.google.com/android/maven2
+maven-central  https://repo1.maven.org/maven2
+plugin-portal  https://plugins.gradle.org/m2
+EOF
+
+if [ -z "$pom" ]; then
+  echo "NOT_FOUND"
+  exit 1
+fi
+
+# Project <url> first, then <scm><url>/<connection>. Take the first <url> that
+# is not the parent/license block — simplest robust heuristic: prefer a github
+# URL anywhere in the POM, else the first project-level <url>.
+homepage=$(grep -oE '<url>[^<]+</url>' <<< "$pom" | sed -E 's#</?url>##g' \
+  | grep -iE 'github\.com' | head -1 || true)
+if [ -z "$homepage" ]; then
+  homepage=$(grep -oE '<connection>[^<]+</connection>' <<< "$pom" \
+    | sed -E 's#</?connection>##g; s#^scm:git:##; s#\.git$##' \
+    | grep -iE 'github\.com' | head -1 || true)
+fi
+if [ -z "$homepage" ]; then
+  # non-github project url (take the first <url> that is not a license/apache one)
+  homepage=$(grep -oE '<url>[^<]+</url>' <<< "$pom" | sed -E 's#</?url>##g' \
+    | grep -ivE 'apache\.org|opensource\.org|license' | head -1 || true)
+fi
+
+if [ -z "$homepage" ]; then
+  echo "NO_HOMEPAGE"
+  exit 1
+fi
+
+# resolve redirects so the printed URL is the canonical one (e.g. the old
+# JetBrains/compose-jb home redirects to JetBrains/compose-multiplatform) — a
+# stored redirecting URL would trip check-changelog-urls.sh.
+canonical() { # $1 = url
+  local final
+  final=$(curl -s -o /dev/null -L --max-time 15 -w '%{url_effective}' "$1" 2>/dev/null) || final="$1"
+  echo "${final%/}"
+}
+
+# --- 2. non-github homepage: return as-is ----------------------------------
+if ! grep -qiE 'github\.com' <<< "$homepage"; then
+  echo "HOMEPAGE  $(canonical "$homepage")"
+  exit 0
+fi
+
+# normalise to github.com/{org}/{repo}
+slug=$(sed -E 's#^.*github\.com[/:]+##; s#\.git$##; s#/+$##' <<< "$homepage")
+org="${slug%%/*}"; repo=$(cut -d/ -f2 <<< "$slug")
+if [ -z "$org" ] || [ -z "$repo" ] || [ "$org" = "$slug" ]; then
+  echo "HOMEPAGE  $(canonical "https://github.com/$slug")"
+  exit 0
+fi
+# canonicalise the repo once (e.g. compose-jb → compose-multiplatform) so both
+# the GitHub API calls and the printed release/tag URLs use the real repo.
+repo_url=$(canonical "https://github.com/$org/$repo")
+slug=$(sed -E 's#^.*github\.com[/:]+##; s#\.git$##; s#/+$##' <<< "$repo_url")
+org="${slug%%/*}"; repo=$(cut -d/ -f2 <<< "$slug")
+
+# --- 3. look for a release / tag matching the version ----------------------
+gh_api() { # $1 = path (no -f: the rate-limit error body must stay readable)
+  local auth=()
+  [ -n "${GITHUB_TOKEN:-}" ] && auth=(-H "Authorization: Bearer $GITHUB_TOKEN")
+  [ -z "${GITHUB_TOKEN:-}" ] && [ -n "${GH_TOKEN:-}" ] && auth=(-H "Authorization: Bearer $GH_TOKEN")
+  curl -sL --max-time 20 "${auth[@]}" \
+    -H 'Accept: application/vnd.github+json' \
+    "https://api.github.com/repos/$org/$repo/$1" 2>/dev/null || true
+}
+
+# A rate-limited lookup must not silently degrade to HOMEPAGE (which would
+# make the agent ask the user for a URL that actually exists).
+rate_limited() { grep -qi 'rate limit exceeded' <<< "$1"; }
+
+vesc=$(sed -E 's/[.]/\\./g' <<< "$version")
+# tag matches version if, ignoring an optional leading `v` and any
+# `prefix-`/`prefix_`/`prefix/` before it, it equals the version exactly.
+# `.` is excluded from the boundary so version 2.60 does not match tag 1.2.60.
+tag_matches='(^|[^0-9.])v?'"$vesc"'$'
+
+# releases (paginated, first 100 is plenty for a recent version)
+releases=$(gh_api "releases?per_page=100")
+if rate_limited "$releases"; then
+  echo "GH_RATE_LIMITED  $repo_url"
+  exit 1
+fi
+rel_tag=$(grep -oE '"tag_name":[[:space:]]*"[^"]+"' <<< "$releases" \
+  | sed -E 's/.*"tag_name":[[:space:]]*"([^"]+)"/\1/' \
+  | grep -E "$tag_matches" | head -1 || true)
+if [ -n "$rel_tag" ]; then
+  echo "RELEASE  $repo_url/releases/tag/$rel_tag"
+  exit 0
+fi
+
+# plain tags
+tags=$(gh_api "tags?per_page=100")
+if rate_limited "$tags"; then
+  echo "GH_RATE_LIMITED  $repo_url"
+  exit 1
+fi
+tag=$(grep -oE '"name":[[:space:]]*"[^"]+"' <<< "$tags" \
+  | sed -E 's/.*"name":[[:space:]]*"([^"]+)"/\1/' \
+  | grep -E "$tag_matches" | head -1 || true)
+if [ -n "$tag" ]; then
+  echo "TAG  $repo_url/releases/tag/$tag"
+  exit 0
+fi
+
+# --- 4. no per-version anchor: repo homepage -------------------------------
+echo "HOMEPAGE  $(canonical "$repo_url")"

--- a/.claude/skills/update-version-catalog/scripts/show-version-diffs.sh
+++ b/.claude/skills/update-version-catalog/scripts/show-version-diffs.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Show the catalog version diffs contained in the release commit (HEAD):
+# a compact per-file list of changed lines (old version = "-" lines, new
+# version = "+" lines) followed by the full patch for context (renames,
+# [libraries]/[plugins] edits).
+#
+# READ-ONLY. Usage: bash show-version-diffs.sh
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+echo "Release commit: $(git log --oneline -1 HEAD)"
+echo
+
+patch=$(git show HEAD --format= -- 'versions-*/libs.versions.toml')
+if [ -z "$patch" ]; then
+  echo "No catalog changes in HEAD."
+  exit 0
+fi
+
+echo "=== changed lines ==="
+grep -E '^(diff --git|[-+][^-+])' <<< "$patch"
+echo
+echo "=== full patch ==="
+printf '%s\n' "$patch"

--- a/.claude/skills/update-version-catalog/scripts/squash-commit.sh
+++ b/.claude/skills/update-version-catalog/scripts/squash-commit.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Squash the cherry-picked bump commits on top of the working branch into one.
+#
+#   bash squash-commit.sh            # message = subjects of squashed commits
+#   bash squash-commit.sh "message"  # explicit message
+#
+# Squashed range: the contiguous run of commits from HEAD down that do NOT
+# touch CHANGELOG.md, stopping at the command base recorded by start-update.sh
+# (falling back to origin/main when no valid base is recorded). Commits at or
+# below the base, and commits touching CHANGELOG.md, are earlier commands'
+# work and are never rewritten (see SKILL.md "Commit rules"). Default message:
+# the subjects of the squashed commits, oldest first, one per line — same as
+# existing release commits on main.
+#
+# SAFETY: refuses to run unless HEAD is a dev-update-* branch and the working
+# tree is clean.
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+cur=$(git branch --show-current)
+case "$cur" in
+  dev-update-*) ;;
+  *) echo "ERROR: not on a dev-update-* branch (on '$cur'). Aborting."; exit 1 ;;
+esac
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "ERROR: working tree not clean — commit or stash first."; exit 1
+fi
+
+# limit below which nothing may be rewritten: the command base recorded by
+# start-update.sh, or origin/main when no valid base is recorded
+limit="origin/main"
+base_file="$(git rev-parse --git-dir)/update-catalog-base"
+if [ -f "$base_file" ]; then
+  read -r mbranch msha < "$base_file" || true
+  if [ "${mbranch:-}" = "$cur" ] && git cat-file -e "${msha:-}^{commit}" 2>/dev/null \
+     && git merge-base --is-ancestor "$msha" HEAD; then
+    limit="$msha"
+  fi
+fi
+
+# contiguous run of commits from HEAD down that do not touch CHANGELOG.md
+count=0
+for c in $(git rev-list "$limit..HEAD"); do
+  if git diff-tree --no-commit-id --name-only -r "$c" | grep -qx 'CHANGELOG.md'; then
+    break
+  fi
+  count=$((count + 1))
+done
+
+if [ "$count" -eq 0 ]; then
+  echo "Nothing to squash (no bump commits on top of the branch)."
+  exit 0
+fi
+if [ "$count" -eq 1 ]; then
+  echo "Only one bump commit on top — nothing to squash."
+  git log --oneline -1
+  exit 0
+fi
+
+base=$(git rev-parse "HEAD~$count")
+if [ "$#" -gt 0 ] && [ -n "$1" ]; then
+  msg="$1"
+else
+  msg=$(git log --reverse --format='%s' "$base..HEAD")
+fi
+
+echo ">>> squashing $count commits on top of: $(git log --oneline -1 "$base")"
+git reset --soft "$base"
+git commit -m "$msg"
+
+echo
+echo "Commits now on $cur (vs origin/main):"
+git log --oneline origin/main..HEAD

--- a/.claude/skills/update-version-catalog/scripts/start-update.sh
+++ b/.claude/skills/update-version-catalog/scripts/start-update.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# Start a command: fetch ALL remote branches (origin/main AND every
+# origin/renovate/* branch — the sources of version bumps), then create (or
+# switch to / stay on) the dev-update-YYYY-MM-DD working branch off the freshly
+# fetched origin/main and record the COMMAND BASE (current HEAD). Local main is
+# never modified.
+#
+#   bash start-update.sh              # today's date
+#   bash start-update.sh 2026-07-09   # explicit date
+#
+# Run ONCE at the start of EVERY command (and not again mid-command):
+# squash-commit.sh and commit-release.sh refuse to rewrite commits at or below
+# the recorded base, which is what protects earlier commands' commits (see
+# SKILL.md "Commit rules").
+#
+# If already on a dev-update-* branch (any date) and no explicit date is given,
+# the script stays on it — earlier commands' commits stay untouched.
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+date="${1:-$(date +%F)}"
+case "$date" in
+  [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) ;;
+  *) echo "ERROR: invalid date '$date' (expected YYYY-MM-DD)."; exit 1 ;;
+esac
+branch="dev-update-$date"
+
+cur=$(git branch --show-current)
+# continuing an earlier session's branch: without an explicit date, stay on it
+case "$cur" in
+  dev-update-*) [ "$#" -eq 0 ] && branch="$cur" ;;
+esac
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "WARNING: working tree has uncommitted changes — they will be carried over." >&2
+fi
+
+# MANDATORY: fetch ALL remote branches before creating/switching to the working
+# branch, so origin/main and every origin/renovate/* branch are up to date.
+# The explicit refspec guarantees renovate branches arrive even if the clone's
+# remote.origin.fetch refspec is narrowed (e.g. a --single-branch clone).
+echo ">>> fetching all branches from origin (incl. renovate/*)"
+git fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'
+
+renovate_count=$(git for-each-ref 'refs/remotes/origin/renovate/*' | wc -l)
+echo ">>> renovate branches available: $renovate_count"
+
+if [ "$cur" = "$branch" ]; then
+  echo ">>> already on $branch — staying on it"
+elif git show-ref --verify --quiet "refs/heads/$branch"; then
+  echo ">>> branch $branch already exists — switching to it"
+  git switch "$branch"
+else
+  echo ">>> creating $branch off origin/main"
+  git switch --no-track -c "$branch" origin/main
+fi
+
+if ! git merge-base --is-ancestor origin/main HEAD; then
+  echo "WARNING: origin/main has advanced past the base of $branch —" >&2
+  echo "         diffs and lint-changelog.sh compare against origin/main and will" >&2
+  echo "         include unrelated changes. Consider releasing/merging this branch" >&2
+  echo "         and starting a fresh one." >&2
+fi
+
+# record the command base: commits at or below this point belong to earlier
+# commands and are protected from squash-commit.sh / commit-release.sh --amend
+printf '%s %s\n' "$branch" "$(git rev-parse HEAD)" > "$(git rev-parse --git-dir)/update-catalog-base"
+echo ">>> command base recorded: $(git log --oneline -1 HEAD)"
+
+echo
+echo "HEAD: $(git log --oneline -1)"
+echo "Commits ahead of origin/main:"
+git log --oneline origin/main..HEAD

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,72 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Gradle Version Catalogs for the red_mad_robot Android team, published to Maven Central under `com.redmadrobot.versions`. Consumer projects import them in `settings.gradle.kts` to synchronize dependency versions.
+
+There is no application code here — the "product" is three `libs.versions.toml` files plus the build machinery that validates and publishes them:
+
+- **versions-androidx** — AndroidX libraries (catalog name in consumers: `androidx`)
+- **versions-redmadrobot** — red_mad_robot open-source libraries (`rmr`)
+- **versions-stack** — internal tech stack of the team (`stack`)
+
+## Architecture
+
+Multi-module build with two composite builds (`includeBuild` in `settings.gradle.kts`):
+
+- `build-logic/` — convention plugins:
+  - `convention.catalog.gradle.kts` — applied by every `versions-*` module; wires the module's `libs.versions.toml` into the `version-catalog` plugin and adds a disambiguation rule preferring the `androidJvm` Kotlin platform variant over `jvm`
+  - `convention.publish.gradle.kts` — Maven Central publishing (vanniktech maven-publish + signing)
+- `version-catalog-extensions/` — standalone plugin `com.redmadrobot.version-catalog-extensions` providing the `validateCatalog` task: it resolves every library and plugin declared in the catalog (so a typo'd coordinate or nonexistent version fails the build) and warns about unused version aliases. It is wired into `check`.
+
+Each `versions-*` module contains only a `libs.versions.toml` and a two-line `build.gradle.kts` applying `convention.catalog`.
+
+## Common Commands
+
+```bash
+# Full verification — what CI runs on every PR (includes validateCatalog)
+./gradlew check
+
+# Validate catalogs only (resolves every declared library/plugin)
+./gradlew validateCatalog
+
+# Validate a single catalog
+./gradlew :versions-stack:validateCatalog
+
+# Generate catalog TOML files (output: <module>/build/version-catalog/libs.versions.toml)
+./gradlew generateCatalogAsToml
+
+# Publish to local Maven for testing in a consumer project
+./gradlew publishToMavenLocal
+```
+
+There are no unit tests; `validateCatalog` is the test suite.
+
+## Catalog Update Workflow
+
+Renovate keeps each dependency bump on its own remote branch `origin/renovate/<dep>`. The bi-weekly update collects those bumps onto a `dev-update-YYYY-MM-DD` branch, records them in `CHANGELOG.md`, and validates with `./gradlew validateCatalog`.
+
+**Use the `update-version-catalog` skill for this** — it also handles adding new dependencies by Maven coordinates. All changelog formatting rules (entry format, release-note links, section structure) are inlined in that skill. Key changelog conventions:
+
+- Sections per release: `### red_mad_robot`, `### AndroidX`, `### Stack`
+- Entry format: ``- :arrow_up: [alias](release-notes-url) `old` → `new` ``
+- Symbols: `:sparkle:` added, `:arrow_up:` updated, `:x:` removed, `:memo:` renamed, `:warning:` attention required (breaking/behaviour changes)
+
+## Editing Catalogs
+
+- Only stable versions; RC allowed for major-issue fixes or compatibility, pre-release allowed when no stable version exists
+- All dependencies in one catalog release must be compatible with each other
+- Library aliases follow Maven coordinates (`androidx.core:core` → `core` in the androidx catalog); drop module names duplicating the group; in the stack catalog a unique library name may omit the group (`com.jakewharton.timber:timber` → `timber`)
+- Every library needs a version alias named after the library alias, so consumers can override versions; shared versions are named after the main dependency
+- Plugin aliases follow the plugin ID; plugin artifacts are also declared in `[libraries]` for buildSrc/composite-build use
+- Avoid Gradle reserved words (e.g. `extensions`) in aliases
+- Full naming rules with examples: README.md "Naming and Structure"
+
+## Releases
+
+- Versions are dates: `YYYY.MM.DD`, kept in `gradle.properties` and the README "Usage" snippet (both updated by the script)
+- `./release.sh` bumps the version, rewrites the `Unreleased` changelog section, commits, tags, and pushes; the tag push triggers `.github/workflows/release.yml`, which publishes to Maven Central and creates a GitHub release with notes extracted from `CHANGELOG.md`
+- Details and manual steps: RELEASING.md
+- Past changelogs are archived per year (`CHANGELOG-2025.md` etc.); only current entries live in `CHANGELOG.md`


### PR DESCRIPTION
Documents the repo architecture and workflow for Claude Code, and adds the update-version-catalog skill to automate the Renovate bump/changelog process.